### PR TITLE
Update services.yml

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -7,7 +7,7 @@ parameters:
   jvdh.assetic_cached_worker.class: jvdh\AsseticCachedWorker\Worker\CachedWorker
 
   jvdh.assetic_cache.class: Assetic\Cache\FilesystemCache
-  jvdh.assetic_filesystem_cache_dir: %kernel.cache_dir%/assetic-cache-busting
+  jvdh.assetic_filesystem_cache_dir: '%kernel.cache_dir%/assetic-cache-busting'
 
 services:
     jvdh.assetic_cache_busting:


### PR DESCRIPTION
Fix: Not quoting the scalar "%kernel.cache_dir%/assetic-cache-busting" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0.